### PR TITLE
Fix for rogue data point issue

### DIFF
--- a/MQTTSNGateway/src/MQTTSNGWClientRecvTask.cpp
+++ b/MQTTSNGateway/src/MQTTSNGWClientRecvTask.cpp
@@ -153,7 +153,8 @@ void ClientRecvTask::run()
 		// on disconnect so we clear the address here 
 		if ( packet->getType() == MQTTSN_CONNECT ){
 			client = _gateway->getClientList()->getClient(senderAddr);
-			client->clearClientAddress();
+			if( client )
+				client->clearClientAddress();
 		}
 
 		client = _gateway->getClientList()->getClient(senderAddr);

--- a/MQTTSNGateway/src/MQTTSNGWClientRecvTask.cpp
+++ b/MQTTSNGateway/src/MQTTSNGWClientRecvTask.cpp
@@ -147,6 +147,15 @@ void ClientRecvTask::run()
 			}
 		}
 
+		// There should be any existing clients in the client list  with 
+		// the same address of a client that is sending a CONNECT message 
+		// if there is that means that it's address wasn't cleared properly 
+		// on disconnect so we clear the address here 
+		if ( packet->getType() == MQTTSN_CONNECT ){
+			client = _gateway->getClientList()->getClient(senderAddr);
+			client->clearClientAddress();
+		}
+
 		client = _gateway->getClientList()->getClient(senderAddr);
 
 		if ( client )


### PR DESCRIPTION
Clear address of any existing client using same address as that of incoming CONNECT packet client